### PR TITLE
Brightspace/Non-Sakai update to research guide

### DIFF
--- a/index.php
+++ b/index.php
@@ -32,14 +32,22 @@ echo '<link href="css/styles.css" type="text/css" rel="stylesheet" media="all" /
 
 //Make sure they have sent a course id
 if (isset($context->info['context_id']) || isset($_GET['course']) ){
+	
+		//Find a username
+		if(isset($context->info['lis_person_sourcedid'])) $lmsUserName = $context->info['lis_person_sourcedid']; //Sakai method
+		elseif (isset($context->info['ext_d2l_username'])) $lmsUserName = $context->info['ext_d2l_username'];  //D2L method
+		else {
+			$lmsUserName=strstr($context->info['lis_person_contact_email_primary'],'@',true); //Most other platforms
+		}
+	
 		//---------------------Login to Admin Area------------------------------//
 		//Start a session
 		session_start();
-		
+	
 		//Hit the database to check if they are an administrator
 		$statement = 'SELECT * FROM `adminUsers` WHERE `campusId` = ?';
 		$exec = $dbConnection->prepare($statement);
-		$exec->execute(array($context->info['lis_person_sourcedid']));
+		$exec->execute(array($lmsUserName));
 		
 		$adminResult = $exec->fetch(PDO::FETCH_ASSOC);
 			
@@ -100,7 +108,7 @@ if (isset($context->info['context_id']) || isset($_GET['course']) ){
 					<label for="campusId">Campus ID:</label>
 					<input type="text" name="campusId" id="campusId" title="ie. aa00aa" required/>
 					<label class="error" id="campusId_error" style="color:#CC0000;display:none;"/>Please Enter your CampusID. ie. aa00aa</label><br />					
-					<input type="hidden" name="addedBy" id="addedBy" value="'.$context->info['lis_person_sourcedid'].'" /><br />
+					<input type="hidden" name="addedBy" id="addedBy" value="'.$lmsUserName.'" /><br />
 					<input type="submit" name="addUser" value="Add User" class="addUser" /></form></div>			
 				';
 
@@ -148,7 +156,7 @@ if (isset($context->info['context_id']) || isset($_GET['course']) ){
 				<label for="link">Link:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</label>
 				<input type="text" name="link" size="80" id="link"/>
 				<label class="error" id="link_error" style="color:#CC0000;display:none;"/>Please Enter the Guide URL. ie. https://www.brocku.ca</label><br />					
-				<input type="hidden" name="addedBySub" id="addedBySub" value="'.$context->info['lis_person_sourcedid'].'" /><br />
+				<input type="hidden" name="addedBySub" id="addedBySub" value="'.$lmsUserName.'" /><br />
 				<input type="submit" name="addGuide" value="Add Guide" class="addGuide" /></form></div>			
 				';
 				//The New guide creation status

--- a/index.php
+++ b/index.php
@@ -37,7 +37,7 @@ if (isset($context->info['context_id']) || isset($_GET['course']) ){
 		if(isset($context->info['lis_person_sourcedid'])) $lmsUserName = $context->info['lis_person_sourcedid']; //Sakai method
 		elseif (isset($context->info['ext_d2l_username'])) $lmsUserName = $context->info['ext_d2l_username'];  //D2L method
 		else {
-			$lmsUserName=strstr($context->info['lis_person_contact_email_primary'],'@',true); //Most other platforms
+			$lmsUserName = strstr($context->info['lis_person_contact_email_primary'],'@',true); //Most other platforms
 		}
 	
 		//---------------------Login to Admin Area------------------------------//

--- a/ltiToBrock.php
+++ b/ltiToBrock.php
@@ -13,9 +13,7 @@ function translateLtiToBrock($lis_course_offering_sourcedid, $title, $userDefaul
 
 		if (is_valid_domain_name(strstr($lis_course_offering_sourcedid,':',true))) { //Does the lis_course_offering_sourcedid look like a TLD? Then this isn't Sakai.
 			$offeringSourcedidArray = str_split($lis_course_offering_sourcedid, strpos($lis_course_offering_sourcedid,":")+1);
-			print_r($offeringSourcedidArray);
 			$sourcedidNG = explode("-", $offeringSourcedidArray[1]);
-
 			
 			//Generate the four and eight code
 			$fourCode = $sourcedidNG[4];

--- a/ltiToBrock.php
+++ b/ltiToBrock.php
@@ -7,12 +7,35 @@
 function translateLtiToBrock($lis_course_offering_sourcedid, $title, $userDefault){
 	
 	//----------First try using the roster approach----------//
-	
-	//Check if lis_course_offering_sourcedid or the custom custom_sourcedid are set	
+
+	//Check if lis_course_offering_sourcedid or the custom custom_sourcedid are set
 	if(isset($lis_course_offering_sourcedid)){
 
-		//First replace the colons with dashes
-		$lis_course_offering_sourcedid = str_replace(":", "-", $lis_course_offering_sourcedid);
+		if (is_valid_domain_name(strstr($lis_course_offering_sourcedid,':',true))) { //Does the lis_course_offering_sourcedid look like a TLD? Then this isn't Sakai.
+			$offeringSourcedidArray = str_split($lis_course_offering_sourcedid, strpos($lis_course_offering_sourcedid,":")+1);
+			print_r($offeringSourcedidArray);
+			$sourcedidNG = explode("-", $offeringSourcedidArray[1]);
+
+			
+			//Generate the four and eight code
+			$fourCode = $sourcedidNG[4];
+			$eightCode = $sourcedidNG[4].$sourcedidNG[5];
+			
+			//Grab the duration
+			$duration = $sourcedidNG[2];
+			
+			//Grab the term
+			$term = $sourcedidNG[1];
+			
+			//Grab the two digit year
+			$year = substr($sourcedidNG[0],2,4); //NN
+			
+			$status = "sourcedid-NG";
+			
+		} 
+		else { //First replace the colons with dashes - Brock University SAKORA-like
+		
+		$lis_course_offering_sourcedid = str_replace(":", "-", $lis_course_offering_sourcedid); //First replace the colons with dashes - Brock University SAKORA-like
 		
 		//We need to account for multiple sections which are deliniated by a plus +
 		$sourcedidArray = explode("+", $lis_course_offering_sourcedid);
@@ -35,6 +58,7 @@ function translateLtiToBrock($lis_course_offering_sourcedid, $title, $userDefaul
 		$fourCode = $allSections[$defaultSection][3];
 		$eightCode = $allSections[$defaultSection][3].$allSections[$defaultSection][4];
 		
+		
 		//Grab the duration
 		$duration = $allSections[$defaultSection][2];
 
@@ -43,9 +67,10 @@ function translateLtiToBrock($lis_course_offering_sourcedid, $title, $userDefaul
 		
 		//Grab the two digit year
 		$year = substr($allSections[$defaultSection][0], 0, 2);
-
+		
 		//Set status of sourcedid
 		$status = "sourcedid";
+		}
 	}
 	//----------Fallback to name parsing----------//
 	else{
@@ -82,3 +107,11 @@ function translateLtiToBrock($lis_course_offering_sourcedid, $title, $userDefaul
 	//Send the four and eight code representations back
 	return array($fourCode, $eightCode, $duration, $term, $year, $status);	
 }
+
+function is_valid_domain_name($domain_name) {
+	return (preg_match("/^([a-zd](-*[a-zd])*)(.([a-zd](-*[a-zd])*))*$/i", $domain_name) //valid characters check
+	&& preg_match("/^.{1,253}$/", $domain_name) //overall length check
+	&& preg_match("/^[^.]{1,63}(.[^.]{1,63})*$/", $domain_name) ); //length of every label
+}
+
+?>


### PR DESCRIPTION
I am recommending this PR to parse Brock University's IPSIS information and alternate sources of username.

index.php checks for a username in 3 locations now (Sakai lis_person_sourcedid, D2L ext_d2l_username, & a parsed lis_person_contact_email_primary if not found). 
ltiToBrock.php now looks for additional formats of offering information in the lis_course_offering_sourcedid. Specifically the non-Sakai format of placing the LMS host in front of the offering information. It is then parsed based on Brock University's IPSIS offering pattern.

New variables introduced are all in camelCase.

Happy to have this tool continue on!